### PR TITLE
Fix warning reported in #99.

### DIFF
--- a/catalog/view/theme/atr374opc2101/template/common/cart.tpl
+++ b/catalog/view/theme/atr374opc2101/template/common/cart.tpl
@@ -22,7 +22,7 @@
             <?php } ?></td>
           <td class="text-right header-cart-quantity">x <?php echo $product['quantity']; ?></td>
           <td class="text-right"><?php echo $product['total']; ?></td>
-          <td class="text-center header-cart-danger"><button type="button" onclick="cart.remove('<?php echo $product['key']; ?>');" title="<?php echo $button_remove; ?>" class="btn btn-danger btn-xs"><i class="fa fa-times"></i></button></td>
+          <td class="text-center header-cart-danger"><button type="button" onclick="cart.remove('<?php echo $product['cart_id']; ?>');" title="<?php echo $button_remove; ?>" class="btn btn-danger btn-xs"><i class="fa fa-times"></i></button></td>
         </tr>
         <?php } ?>
         <?php foreach ($vouchers as $voucher) { ?>


### PR DESCRIPTION
It seems that 'key' must have been renamed to 'product_id' but wasn't updated in our template.