### PR TITLE
Fix warning about name

### DIFF
--- a/api/v1/catalog/controller/product/product.php
+++ b/api/v1/catalog/controller/product/product.php
@@ -224,7 +224,7 @@ class ControllerProductProductAPI extends ControllerProductProductBaseAPI {
 
         if ($this->config->get('mvd_product_notification')) {
 				$this->add_edit_notification(false, $description['name']);
-				$this->add_edit_vendor_notification(false, $this->request->post['name']);
+				$this->add_edit_vendor_notification(false, $description['name']);
         }
 	}
 


### PR DESCRIPTION
(attempting to take product name from wrong array, which didn't necessarily have name set depending on the request made).