### PR TITLE
Fix admin order editing problem

### DIFF
--- a/catalog/controller/api/order.php
+++ b/catalog/controller/api/order.php
@@ -100,7 +100,6 @@ class ControllerApiOrder extends Controller {
 				$order_data['invoice_prefix'] = $this->config->get('config_invoice_prefix');
 				$order_data['store_id'] = $this->config->get('config_store_id');
 				$order_data['store_name'] = $this->config->get('config_name');
-				$order_data['store_url'] = $this->config->get('config_url');
 				$order_data['store_url'] = $this->config->get('config_secure') ? $this->config->get('config_ssl') : $this->config->get('config_url');
 
 				// Customer Details

--- a/catalog/controller/api/order.php
+++ b/catalog/controller/api/order.php
@@ -101,6 +101,7 @@ class ControllerApiOrder extends Controller {
 				$order_data['store_id'] = $this->config->get('config_store_id');
 				$order_data['store_name'] = $this->config->get('config_name');
 				$order_data['store_url'] = $this->config->get('config_url');
+				$order_data['store_url'] = $this->config->get('config_secure') ? $this->config->get('config_ssl') : $this->config->get('config_url');
 
 				// Customer Details
 				$order_data['customer_id'] = $this->session->data['customer']['customer_id'];
@@ -467,7 +468,7 @@ class ControllerApiOrder extends Controller {
 					$order_data['invoice_prefix'] = $this->config->get('config_invoice_prefix');
 					$order_data['store_id'] = $this->config->get('config_store_id');
 					$order_data['store_name'] = $this->config->get('config_name');
-					$order_data['store_url'] = $this->config->get('config_url');
+					$order_data['store_url'] = $this->config->get('config_secure') ? $this->config->get('config_ssl') : $this->config->get('config_url');
 
 					// Customer Details
 					$order_data['customer_id'] = $this->session->data['customer']['customer_id'];


### PR DESCRIPTION
(Edit was storing the plain http URL as store_url, when it should have been storing the https store URL.
This then caused issues when the order edit page was next loaded.)